### PR TITLE
Fix clearer error message when CouchDB is unavailable

### DIFF
--- a/src/main/java/chatbot/Application.java
+++ b/src/main/java/chatbot/Application.java
@@ -136,7 +136,10 @@ public class Application {
                 eliza = new ElizaMain();
                 eliza.readScript(true, "src/main/resources/eliza/script");
 
-                sparql = (explorerDB != null) ? new SPARQL(explorerDB) : null;
+                sparql = (explorerDB != null)
+                        ? new SPARQL(explorerDB)
+                        : SPARQL.disabled();
+
                 languageTool = new JLanguageTool(new AmericanEnglish());
                 for (Rule rule : languageTool.getAllActiveRules()) {
                     if (rule instanceof SpellingCheckRule) {

--- a/src/main/java/chatbot/lib/api/SPARQL.java
+++ b/src/main/java/chatbot/lib/api/SPARQL.java
@@ -68,6 +68,12 @@ public class SPARQL {
             public int isDisambiguationPage(String uri) {
                 return 0;
             }
+
+            @Override
+            public ArrayList<ResponseData> getEntitiesByURIs(String uris) {
+                // CouchDB down → return safe empty result
+                return new ArrayList<>();
+            }
         };
     }
 


### PR DESCRIPTION
Improves error handling when CouchDB / Cloudant is unavailable by:
- Logging a clear error instead of failing silently
- Guarding SPARQL initialization to avoid null-pointer crashes

This makes the application more robust when the explorer database is down.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App provides a safe limited/offline mode when the knowledge database is unavailable, returning placeholder responses instead of failing.

* **Bug Fixes**
  * Improved handling and clearer logging for database connectivity issues, eliminating noisy stack traces.

* **Refactor**
  * Minor formatting and structural cleanups to improve maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->