### PR TITLE
Add API documentation for webhook endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ POST /webhook
 Content-Type: application/json
 ```
 
-**Note:** This endpoint is publicly accessible and does not require authentication.
+**Note:** This is a public webhook endpoint that does not require authentication. Currently, no application-level rate limiting is configured. For production deployments, consider implementing rate limiting via an API gateway or reverse proxy (e.g., nginx, AWS API Gateway) to prevent abuse.
 
 ### Request Format
 ```json

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Add the following snippet to the `<head>` section of the webpage where you want 
 The chatbot exposes a REST API that allows developers to integrate chatbot functionality into their applications.
 
 ### Endpoint
-```
+```http
 POST /webhook
 Content-Type: application/json
 ```

--- a/README.md
+++ b/README.md
@@ -98,6 +98,119 @@ Add the following snippet to the `<head>` section of the webpage where you want 
 </script>
 ```
 
+## API Usage
+The chatbot exposes a REST API that allows developers to integrate chatbot functionality into their applications.
+
+### Endpoint
+```
+POST /webhook
+Content-Type: application/json
+```
+
+**Note:** This endpoint is publicly accessible and does not require authentication.
+
+### Request Format
+```json
+{
+  "userId": "unique-user-id",
+  "messageType": "text",
+  "messageData": [
+    {
+      "text": "Your question here"
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| userId | string | Unique identifier for the user/session |
+| messageType | string | `text` for queries, `parameter` for button responses |
+| messageData | array | Array containing message objects with `text` field |
+
+### Response Format
+The API returns an array of response objects:
+```json
+[
+  {
+    "messageType": "text",
+    "messageData": [
+      {
+        "title": "Entity Title",
+        "text": "Response content",
+        "image": "https://example.com/image.jpg",
+        "buttons": []
+      }
+    ]
+  }
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| messageType | string | Type of response (typically `text`) |
+| messageData | array | Array of response objects |
+| title | string | Title/subject of the response |
+| text | string | Main response content |
+| image | string | URL to related image (optional, may be empty) |
+| buttons | array | Interactive buttons for follow-up actions (optional) |
+
+### Example
+
+**Request:**
+```sh
+curl -X POST https://chat.dbpedia.org/webhook \
+  -H "Content-Type: application/json" \
+  -d '{
+    "userId": "test-user-123",
+    "messageType": "text",
+    "messageData": [{"text": "Who is Albert Einstein?"}]
+  }'
+```
+
+**Response:**
+```json
+[
+  {
+    "messageType": "text",
+    "messageData": [
+      {
+        "title": "Albert Einstein",
+        "text": "Albert Einstein was a German-born theoretical physicist...",
+        "image": "https://commons.wikimedia.org/wiki/Special:FilePath/Einstein_1921.jpg",
+        "buttons": []
+      }
+    ]
+  }
+]
+```
+
+### Sample Queries
+- "Who is Albert Einstein?"
+- "What is the capital of France?"
+- "Tell me about DBpedia"
+- "Where is Paris?"
+
+### Limitations & Notes
+
+- **Supported messageType values:** Only `text` and `parameter` are currently supported
+- **Query length:** For optimal results, keep queries concise (under 200 characters recommended)
+- **Character encoding:** UTF-8 is fully supported, including special characters (², €, etc.)
+- **Error responses:** Invalid messageType or malformed requests may return HTTP 500 errors
+
+### Testing Locally
+
+If running the chatbot locally:
+```sh
+curl -X POST http://localhost:8080/webhook \
+  -H "Content-Type: application/json" \
+  -d '{
+    "userId": "test-user",
+    "messageType": "text",
+    "messageData": [{"text": "Hello"}]
+  }'
+```
+
 ## Citation
 ```
 @inproceedings{ramngongausbeck2018,


### PR DESCRIPTION
Adds API documentation for the /`webhook` endpoint to help developers integrate 
the chatbot programmatically.

Changes:
- Endpoint details `POST /webhook`
- Request/response formats with examples
- Sample queries and limitations
- Local testing instructions

Tested against live API all documented formats verified.

resolves issue #55 




## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive API Usage documentation for the publicly accessible REST endpoint (POST /webhook). Includes endpoint metadata, request and response payload schemas with JSON examples, field descriptions, usage limitations, sample queries, and step‑by‑step local testing guidance.

