### PR TITLE
Upgrade Spring Boot to 2.7.18 and enable Java 17 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.2.RELEASE</version>
+        <version>2.7.18</version>
     </parent>
 
     <repositories>
@@ -41,6 +41,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
@@ -140,7 +145,7 @@
     </dependencies>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Fixes #58

This PR upgrades the project from Spring Boot 1.5.2.RELEASE to 2.7.18 and updates the Java target version to 17.

Reason:
Spring Boot 1.5.x and Spring Framework 4.x rely on reflection mechanisms that fail on Java 11+ due to the module system, causing:
java.lang.reflect.InaccessibleObjectException

Upgrading to Spring Boot 2.7.18 (Spring Framework 5.3.x) removes this problem and provides full Java 17 compatibility without requiring --add-opens JVM flags.

Changes:
- Updated spring-boot-starter-parent to 2.7.18
- Set java.version to 17
- Added spring-boot-starter-web (project uses Spring MVC)

Verification:
- mvn clean install -DskipTests "-Dskip.npm=true"
- mvn spring-boot:run "-Dskip.npm=true"

Build and application start successfully on Java 21 compiling to Java 17.
Note: Some integration tests require external DBpedia services and may fail locally; therefore verification was done using -DskipTests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Java runtime requirement from Java 8 to Java 17
  * Upgraded Spring Boot framework to version 2.7.18 for improved stability, security, and long-term support
  * Enhanced web framework capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->