### PR TITLE
Better Error message when CouchDB is unavailable

### DIFF
--- a/src/main/java/chatbot/Application.java
+++ b/src/main/java/chatbot/Application.java
@@ -46,7 +46,8 @@ public class Application {
     private static final Logger logger = LoggerFactory.getLogger(Application.class);
 
     @Bean
-    public MessengerSendClient initializeFBMessengerSendClient(@Value("${chatbot.fb.pageAccessToken}") String pageAccessToken) {
+    public MessengerSendClient initializeFBMessengerSendClient(
+            @Value("${chatbot.fb.pageAccessToken}") String pageAccessToken) {
         logger.info("Initializing MessengerSendClient - pageAccessToken: {}", pageAccessToken);
         return MessengerPlatform.newSendClientBuilder(pageAccessToken).build();
     }
@@ -55,10 +56,14 @@ public class Application {
     static class AssetsConfiguration extends WebMvcConfigurerAdapter {
         @Override
         public void addResourceHandlers(ResourceHandlerRegistry registry) {
-            registry.addResourceHandler("/assets/**").addResourceLocations("file:node_modules/").setCacheControl(CacheControl.maxAge(1, TimeUnit.DAYS));
-            registry.addResourceHandler("/js/**").addResourceLocations("file:src/main/app/js/").setCacheControl(CacheControl.maxAge(1, TimeUnit.DAYS));
-            registry.addResourceHandler("/css/**").addResourceLocations("file:src/main/app/css/").setCacheControl(CacheControl.maxAge(1, TimeUnit.DAYS));
-            registry.addResourceHandler("/images/**").addResourceLocations("file:src/main/resources/static/images/").setCacheControl(CacheControl.maxAge(1, TimeUnit.DAYS));
+            registry.addResourceHandler("/assets/**").addResourceLocations("file:node_modules/")
+                    .setCacheControl(CacheControl.maxAge(1, TimeUnit.DAYS));
+            registry.addResourceHandler("/js/**").addResourceLocations("file:src/main/app/js/")
+                    .setCacheControl(CacheControl.maxAge(1, TimeUnit.DAYS));
+            registry.addResourceHandler("/css/**").addResourceLocations("file:src/main/app/css/")
+                    .setCacheControl(CacheControl.maxAge(1, TimeUnit.DAYS));
+            registry.addResourceHandler("/images/**").addResourceLocations("file:src/main/resources/static/images/")
+                    .setCacheControl(CacheControl.maxAge(1, TimeUnit.DAYS));
             super.addResourceHandlers(registry);
         }
     }
@@ -74,7 +79,9 @@ public class Application {
             http
                     .csrf().disable()
                     .authorizeRequests()
-                    .antMatchers("/", "/assets/**/*", "/js/*", "/images/**/*", "/feedback", "/webhook", "/fbwebhook", "/slackwebhook", "/embed").permitAll()
+                    .antMatchers("/", "/assets/**/*", "/js/*", "/images/**/*", "/feedback", "/webhook", "/fbwebhook",
+                            "/slackwebhook", "/embed")
+                    .permitAll()
                     .anyRequest().authenticated()
                     .and()
                     .formLogin()
@@ -88,7 +95,9 @@ public class Application {
         }
 
         @Autowired
-        protected void configureGlobal(AuthenticationManagerBuilder auth, @Value("${admin.username}") String username, @Value("${admin.password}") String password, @Value("${chatbot.baseUrl}") String baseUrl) throws Exception {
+        protected void configureGlobal(AuthenticationManagerBuilder auth, @Value("${admin.username}") String username,
+                @Value("${admin.password}") String password, @Value("${chatbot.baseUrl}") String baseUrl)
+                throws Exception {
             this.baseUrl = baseUrl;
             auth
                     .inMemoryAuthentication()
@@ -108,21 +117,18 @@ public class Application {
 
         @Autowired
         public Helper(final CloudantClient cloudantClient,
-                      WolframRepository wolframRepository,
-                      @Value("${cloudant.chatDB}") String chatDBName,
-                      @Value("${cloudant.feedbackDB}") String feedbackDBName,
-                      @Value("${cloudant.explorerDB}") String explorerDBName,
-                      @Value("${tmdb.apiKey}") String tmdbApiKey) {
+                WolframRepository wolframRepository,
+                @Value("${cloudant.chatDB}") String chatDBName,
+                @Value("${cloudant.feedbackDB}") String feedbackDBName,
+                @Value("${cloudant.explorerDB}") String explorerDBName,
+                @Value("${tmdb.apiKey}") String tmdbApiKey) {
             try {
                 chatDB = cloudantClient.database(chatDBName, true);
                 feedbackDB = cloudantClient.database(feedbackDBName, true);
                 explorerDB = cloudantClient.database(explorerDBName, true);
-            }
-            catch(Exception e) {
-                logger.info("ERROR HERE");
-                e.printStackTrace();
-            }
-            finally {
+            } catch (Exception e) {
+                logger.error("CouchDB / Cloudant is unavailable. Explorer properties will not be loaded.", e);
+            } finally {
                 this.tmdbApiKey = tmdbApiKey;
                 this.wolframRepository = wolframRepository;
 
@@ -130,11 +136,14 @@ public class Application {
                 eliza = new ElizaMain();
                 eliza.readScript(true, "src/main/resources/eliza/script");
 
-                sparql = new SPARQL(explorerDB);
+                sparql = (explorerDB != null)
+                        ? new SPARQL(explorerDB)
+                        : SPARQL.disabled();
+
                 languageTool = new JLanguageTool(new AmericanEnglish());
                 for (Rule rule : languageTool.getAllActiveRules()) {
                     if (rule instanceof SpellingCheckRule) {
-                        List<String> wordsToIgnore = Arrays.asList(new String[] {"nlp", "merkel"});
+                        List<String> wordsToIgnore = Arrays.asList(new String[] { "nlp", "merkel" });
                         ((SpellingCheckRule) rule).addIgnoreTokens(wordsToIgnore);
                     }
                 }
@@ -167,6 +176,10 @@ public class Application {
 
         public Database getExplorerDB() {
             return explorerDB;
+        }
+
+        public boolean isExplorerDBAvailable() {
+            return explorerDB != null;
         }
 
         public SPARQL getSparql() {

--- a/src/main/java/chatbot/Application.java
+++ b/src/main/java/chatbot/Application.java
@@ -48,7 +48,7 @@ public class Application {
     @Bean
     public MessengerSendClient initializeFBMessengerSendClient(
             @Value("${chatbot.fb.pageAccessToken}") String pageAccessToken) {
-        logger.info("Initializing MessengerSendClient - pageAccessToken: {}", pageAccessToken);
+        logger.info("Initializing MessengerSendClient");
         return MessengerPlatform.newSendClientBuilder(pageAccessToken).build();
     }
 

--- a/src/main/java/chatbot/lib/api/SPARQL.java
+++ b/src/main/java/chatbot/lib/api/SPARQL.java
@@ -94,25 +94,38 @@ public class SPARQL {
     // Additionally can be checked to contain unnecessary characters instead of
     // blindly stripping based on brackets
     private String stripWikiepdiaContent(String text) {
-        int indexStart = text.indexOf("("), indexEnd;
+        int indexStart = text.indexOf("(");
         if (indexStart > 0) {
-            indexEnd = text.indexOf(")", indexStart) + 2;
-            if (indexEnd != -1) {
-                return text.replace(text.substring(indexStart, indexEnd), "");
+            int indexEnd = text.indexOf(")", indexStart);
+            if (indexEnd == -1) {
+                // No closing paren found, return unchanged
+                return text;
             }
+            // Include the closing paren in the removal, ensure we don't exceed text length
+            indexEnd = Math.min(indexEnd + 1, text.length());
+            return text.substring(0, indexStart) + text.substring(indexEnd);
         } else if (indexStart == 0) {
             // When abstract starts with info on Disambiguation
-            indexEnd = text.lastIndexOf("(disambiguation).)");
-            if (indexEnd != -1) {
-                return text.replace(text.substring(indexStart, indexEnd + 18), "");
+            int disIndex = text.lastIndexOf("(disambiguation).)");
+            if (disIndex == -1) {
+                // Pattern not found, return unchanged
+                return text;
             }
+            // Calculate end index safely, ensuring we don't exceed text length
+            int endIndex = Math.min(disIndex + 18, text.length());
+            return text.substring(endIndex);
         }
         return text;
     }
 
     private String processWikipediaAbstract(String abs) {
         while (abs.indexOf("(") != -1) {
+            String before = abs;
             abs = stripWikiepdiaContent(abs);
+            // Break if no change was made to prevent infinite loop on malformed input
+            if (abs.equals(before)) {
+                break;
+            }
         }
         return abs;
     }

--- a/src/main/java/chatbot/lib/api/SPARQL.java
+++ b/src/main/java/chatbot/lib/api/SPARQL.java
@@ -38,8 +38,44 @@ public class SPARQL {
     );
 
     Database explorerDB;
+
     public SPARQL(Database explorerDB) {
         this.explorerDB = explorerDB;
+    }
+
+    /**
+     * Safe disabled SPARQL instance used when CouchDB is unavailable.
+     * Prevents NullPointerExceptions across the application.
+     */
+    public static SPARQL disabled() {
+        return new SPARQL(null) {
+
+            @Override
+            public ResponseData getEntityInformation(String uri) {
+                ResponseData response = new ResponseData();
+                response.setTitle("Explorer database unavailable");
+                response.setText(
+                        "The DBpedia explorer database is currently unavailable. " +
+                                "Please try again later.");
+                return response;
+            }
+
+            @Override
+            public String getLabel(String uri) {
+                return "Explorer database unavailable";
+            }
+
+            @Override
+            public int isDisambiguationPage(String uri) {
+                return 0;
+            }
+
+            @Override
+            public ArrayList<ResponseData> getEntitiesByURIs(String uris) {
+                // CouchDB down → return safe empty result
+                return new ArrayList<>();
+            }
+        };
     }
 
     private static final String ENTITY_SELECT_PARAMETERS = " ?label ?abstract ?primaryTopic ?thumbnail ?description ";

--- a/src/main/java/chatbot/lib/api/SPARQL.java
+++ b/src/main/java/chatbot/lib/api/SPARQL.java
@@ -29,13 +29,12 @@ public class SPARQL {
     private static final String ENDPOINT = "https://dbpedia.org/sparql";
     private static final String PREFIXES = new String(
             "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n" +
-            "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"+
-            "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n" +
-            "PREFIX dbo: <http://dbpedia.org/ontology/>\n" +
-            "PREFIX dbp: <http://dbpedia.org/property/>\n" +
-            "PREFIX dbr: <http://dbpedia.org/resource/>\n" +
-            "PREFIX dct: <http://purl.org/dc/terms/>\n"
-    );
+                    "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +
+                    "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n" +
+                    "PREFIX dbo: <http://dbpedia.org/ontology/>\n" +
+                    "PREFIX dbp: <http://dbpedia.org/property/>\n" +
+                    "PREFIX dbr: <http://dbpedia.org/resource/>\n" +
+                    "PREFIX dct: <http://purl.org/dc/terms/>\n");
 
     Database explorerDB;
 
@@ -75,6 +74,12 @@ public class SPARQL {
                 // CouchDB down → return safe empty result
                 return new ArrayList<>();
             }
+
+            @Override
+            public ArrayList<ResponseData> getDisambiguatedEntities(String uri, int offset, int limit) {
+                // CouchDB down → return safe empty result to prevent NPE
+                return new ArrayList<>();
+            }
         };
     }
 
@@ -84,20 +89,21 @@ public class SPARQL {
         return PREFIXES + query;
     }
 
-    // Remove the pronounciation information that appears at the beginning of the article enclosed by ()
-    // Additionally can be checked to contain unnecessary characters instead of blindly stripping based on brackets
+    // Remove the pronounciation information that appears at the beginning of the
+    // article enclosed by ()
+    // Additionally can be checked to contain unnecessary characters instead of
+    // blindly stripping based on brackets
     private String stripWikiepdiaContent(String text) {
         int indexStart = text.indexOf("("), indexEnd;
-        if(indexStart > 0) {
+        if (indexStart > 0) {
             indexEnd = text.indexOf(")", indexStart) + 2;
-            if(indexEnd != -1) {
+            if (indexEnd != -1) {
                 return text.replace(text.substring(indexStart, indexEnd), "");
             }
-        }
-        else if(indexStart == 0) {
+        } else if (indexStart == 0) {
             // When abstract starts with info on Disambiguation
             indexEnd = text.lastIndexOf("(disambiguation).)");
-            if(indexEnd != -1) {
+            if (indexEnd != -1) {
                 return text.replace(text.substring(indexStart, indexEnd + 18), "");
             }
         }
@@ -105,7 +111,7 @@ public class SPARQL {
     }
 
     private String processWikipediaAbstract(String abs) {
-        while(abs.indexOf("(") != -1) {
+        while (abs.indexOf("(") != -1) {
             abs = stripWikiepdiaContent(abs);
         }
         return abs;
@@ -120,31 +126,16 @@ public class SPARQL {
             return className;
         }
 
-        public ExplorerProperties setClassName(String className) {
-            this.className = className;
-            return this;
-        }
-
         public String getProperty() {
             return property;
-        }
-
-        public ExplorerProperties setProperty(String property) {
-            this.property = property;
-            return this;
         }
 
         public String getScore() {
             return score;
         }
-
-        public ExplorerProperties setScore(String score) {
-            this.score = score;
-            return this;
-        }
     }
 
-    private List<ResponseData.Field> getRelevantProperties(String uri, List types, String[] properties) {
+    private List<ResponseData.Field> getRelevantProperties(String uri, List<String> types, String[] properties) {
         List<ResponseData.Field> fields = new ArrayList<>();
         try {
             TreeMap<Float, String> propertyMap = new TreeMap<>();
@@ -154,15 +145,15 @@ public class SPARQL {
                     .inclusiveEnd(true)
                     .build().getResponse().getValues();
 
-
-            for(ExplorerProperties property : explorerProperties) {
-                // Check if the property matches one of the list of classes(types) found for the entity
-                if(types.contains(property.getClassName())) {
+            for (ExplorerProperties property : explorerProperties) {
+                // Check if the property matches one of the list of classes(types) found for the
+                // entity
+                if (types.contains(property.getClassName())) {
                     propertyMap.put(Float.parseFloat(property.getScore()), property.getProperty());
                 }
             }
 
-            if(propertyMap.size() > 0) {
+            if (propertyMap.size() > 0) {
                 int count = 0;
                 Iterator<Float> iterator = propertyMap.descendingKeySet().iterator();
                 String property_uris = "";
@@ -171,30 +162,33 @@ public class SPARQL {
                     count++;
                 }
 
-                String query = buildQuery("SELECT ?property_label (group_concat(distinct ?value;separator='__') as ?values) (group_concat(distinct ?value_label;separator='__') as ?value_labels) where {\n" +
-                        "VALUES ?property {" + property_uris + "}\n" +
-                        "<" + uri + "> ?property ?value . \n" +
-                        "?property rdfs:label ?property_label . FILTER(lang(?property_label)='en'). \n" +
-                        "OPTIONAL {?value rdfs:label ?value_label . FILTER(lang(?value_label) = 'en') }\n" +
-                        "} GROUP BY ?property_label");
+                String query = buildQuery(
+                        "SELECT ?property_label (group_concat(distinct ?value;separator='__') as ?values) (group_concat(distinct ?value_label;separator='__') as ?value_labels) where {\n"
+                                +
+                                "VALUES ?property {" + property_uris + "}\n" +
+                                "<" + uri + "> ?property ?value . \n" +
+                                "?property rdfs:label ?property_label . FILTER(lang(?property_label)='en'). \n" +
+                                "OPTIONAL {?value rdfs:label ?value_label . FILTER(lang(?value_label) = 'en') }\n" +
+                                "} GROUP BY ?property_label");
                 QueryExecution queryExecution = executeQuery(query);
                 try {
                     Iterator<QuerySolution> results = queryExecution.execSelect();
-                    while(results.hasNext()) {
+                    while (results.hasNext()) {
                         QuerySolution result = results.next();
                         ResponseData.Field field = new ResponseData.Field();
                         field.setName(Utility.capitalizeAll(result.get("property_label").asLiteral().getString()));
 
-                        // If Value Label String is empty then we use Value String instead which means the value is a literal. So we are only taking the first element before space
-                        if(result.get("value_labels").asLiteral().getString().equals("")) {
-                            field.setValue(Utility.capitalizeAll(result.get("values").asLiteral().getString().split("__")[0]));
-                        }
-                        else {
+                        // If Value Label String is empty then we use Value String instead which means
+                        // the value is a literal. So we are only taking the first element before space
+                        if (result.get("value_labels").asLiteral().getString().equals("")) {
+                            field.setValue(
+                                    Utility.capitalizeAll(result.get("values").asLiteral().getString().split("__")[0]));
+                        } else {
                             LinkedHashMap<String, String> map = new LinkedHashMap<>();
                             String[] keyArray = result.get("values").asLiteral().getString().split("__");
                             String[] valueArray = result.get("value_labels").asLiteral().getString().split("__");
 
-                            for(int index = 0; index < keyArray.length; index++) {
+                            for (int index = 0; index < keyArray.length; index++) {
                                 map.put(Utility.convertDBpediaToWikipediaURL(keyArray[index]), valueArray[index]);
                             }
                             field.setValues(map);
@@ -202,17 +196,13 @@ public class SPARQL {
                         fields.add(field);
                     }
                     return fields;
-                }
-                finally {
+                } finally {
                     queryExecution.close();
-                    return fields;
                 }
-            }
-            else {
+            } else {
                 return fields;
             }
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return fields;
@@ -223,23 +213,24 @@ public class SPARQL {
         ResponseData responseData = new ResponseData();
         String label = result.get("label").asLiteral().getString(), text = "";
         responseData.setTitle(label);
-        responseData.addButton(new ResponseData.Button("View in Wikipedia", ResponseType.BUTTON_LINK, result.get("primaryTopic").toString()));
+        responseData.addButton(new ResponseData.Button("View in Wikipedia", ResponseType.BUTTON_LINK,
+                result.get("primaryTopic").toString()));
 
         node = result.get("thumbnail");
-        if(node != null) {
+        if (node != null) {
             responseData.setImage(node.toString());
         }
 
-//        String summary = new GenesisService().getSummary(uri);
-//        if(summary == null || summary.isEmpty()) {
-//            node = result.get(VAR_ABSTRACT);
-//            if(node != null) {
-//                summary = processWikipediaAbstract(node.asLiteral().getString());
-//            }
-//        }
+        // String summary = new GenesisService().getSummary(uri);
+        // if(summary == null || summary.isEmpty()) {
+        // node = result.get(VAR_ABSTRACT);
+        // if(node != null) {
+        // summary = processWikipediaAbstract(node.asLiteral().getString());
+        // }
+        // }
 
         node = result.get("description");
-        if(node != null) {
+        if (node != null) {
             text += node.asLiteral().getString() + "\n\n";
         }
 
@@ -254,35 +245,39 @@ public class SPARQL {
         }
 
         String query = buildQuery(
-                "SELECT (GROUP_CONCAT(distinct ?type;separator=' ') as ?types) (GROUP_CONCAT(distinct ?property;separator=' ') as ?properties) WHERE {\n" +
-                "<" + uri + "> rdf:type ?type . FILTER(STRSTARTS(STR(?type), 'http://dbpedia.org/ontology')) . \n" +
-                "<" + uri + "> ?property ?value . FILTER(STRSTARTS(STR(?property), 'http://dbpedia.org/ontology')) . \n" +
-        "}");
+                "SELECT (GROUP_CONCAT(distinct ?type;separator=' ') as ?types) (GROUP_CONCAT(distinct ?property;separator=' ') as ?properties) WHERE {\n"
+                        +
+                        "<" + uri
+                        + "> rdf:type ?type . FILTER(STRSTARTS(STR(?type), 'http://dbpedia.org/ontology')) . \n" +
+                        "<" + uri
+                        + "> ?property ?value . FILTER(STRSTARTS(STR(?property), 'http://dbpedia.org/ontology')) . \n" +
+                        "}");
         QueryExecution queryExecution = executeQuery(query);
         try {
             Iterator<QuerySolution> results = queryExecution.execSelect();
-            while(results.hasNext()) {
+            while (results.hasNext()) {
                 QuerySolution solution = results.next();
-                if(solution.get("types") != null && solution.get("properties") != null) {
+                if (solution.get("types") != null && solution.get("properties") != null) {
                     List<String> types = Arrays.asList(solution.get("types").asLiteral().getString().split(" "));
                     String[] properties = solution.get("properties").asLiteral().getString().split(" ");
                     responseData.setFields(getRelevantProperties(uri, types, properties));
                 }
             }
-        }
-        finally {
+        } finally {
             queryExecution.close();
         }
 
         responseData.addButton(new ResponseData.Button("View in DBpedia", ResponseType.BUTTON_LINK, uri));
-        responseData.addButton(new ResponseData.Button("Learn More", ResponseType.BUTTON_PARAM, TemplateType.LEARN_MORE + Utility.STRING_SEPARATOR + uri + Utility.STRING_SEPARATOR + label));
+        responseData.addButton(new ResponseData.Button("Learn More", ResponseType.BUTTON_PARAM,
+                TemplateType.LEARN_MORE + Utility.STRING_SEPARATOR + uri + Utility.STRING_SEPARATOR + label));
         return responseData;
     }
 
     private String getEntityWhereCondition(String uri) {
         // URI could either be the actual URI or a variable reference
-        // In case of actual URI it needs to be enclosed with <uri> which is not required for variable reference
-        if(!uri.startsWith("?")) {
+        // In case of actual URI it needs to be enclosed with <uri> which is not
+        // required for variable reference
+        if (!uri.startsWith("?")) {
             uri = "<" + uri + ">";
         }
         return uri + " rdfs:label ?label .\n" +
@@ -296,18 +291,17 @@ public class SPARQL {
     public ResponseData getEntityInformation(String uri) {
         String query = buildQuery("SELECT " + ENTITY_SELECT_PARAMETERS + " WHERE {" +
                 getEntityWhereCondition(uri) +
-        "}");
+                "}");
         QueryExecution queryExecution = executeQuery(query);
         ResponseData responseData = null;
 
         try {
             Iterator<QuerySolution> results = queryExecution.execSelect();
-            while(results.hasNext()) {
+            while (results.hasNext()) {
                 QuerySolution result = results.next();
                 responseData = processEntityInformation(uri, result);
             }
-        }
-        finally {
+        } finally {
             queryExecution.close();
         }
         return responseData;
@@ -316,23 +310,23 @@ public class SPARQL {
     /**
      * Returns 0 if it is not a disambiguation page. Returns count otherwise
      * We can only show 10 at a time so its limited by that
+     * 
      * @return 0 or count
      */
     public int isDisambiguationPage(String uri) {
-         String query = buildQuery("SELECT (count(*) as ?count) WHERE {" +
-                 "<" + uri + "> <http://dbpedia.org/ontology/wikiPageDisambiguates> ?o." +
-                 "}");
+        String query = buildQuery("SELECT (count(*) as ?count) WHERE {" +
+                "<" + uri + "> <http://dbpedia.org/ontology/wikiPageDisambiguates> ?o." +
+                "}");
         QueryExecution queryExecution = executeQuery(query);
         int count = 0;
 
         try {
             Iterator<QuerySolution> results = queryExecution.execSelect();
-            while(results.hasNext()) {
+            while (results.hasNext()) {
                 QuerySolution result = results.next();
                 count = result.get("count").asLiteral().getInt();
             }
-        }
-        finally {
+        } finally {
             queryExecution.close();
         }
         return count;
@@ -346,13 +340,12 @@ public class SPARQL {
             Iterator<QuerySolution> results = queryExecution.execSelect();
             if (results != null) {
                 responseDatas = new ArrayList<>();
-                while(results.hasNext()) {
+                while (results.hasNext()) {
                     QuerySolution result = results.next();
                     responseDatas.add(processEntityInformation(result.get("uri").toString(), result));
                 }
             }
-        }
-        finally {
+        } finally {
             queryExecution.close();
         }
         return responseDatas;
@@ -362,7 +355,7 @@ public class SPARQL {
         String query = buildQuery("SELECT ?uri " + ENTITY_SELECT_PARAMETERS + " WHERE {\n" +
                 "<" + uri + "> <http://dbpedia.org/ontology/wikiPageDisambiguates> ?uri .\n" +
                 getEntityWhereCondition("?uri") +
-        "} ORDER BY ?uri OFFSET " + offset + " LIMIT " + limit);
+                "} ORDER BY ?uri OFFSET " + offset + " LIMIT " + limit);
         return getEntities(query);
     }
 
@@ -385,8 +378,7 @@ public class SPARQL {
         try {
             Iterator<QuerySolution> results = queryExecution.execSelect();
             label = results.next().get("label").asLiteral().getString();
-        }
-        finally {
+        } finally {
             queryExecution.close();
         }
         return label;
@@ -396,19 +388,18 @@ public class SPARQL {
         String types = null;
         String query = buildQuery("SELECT (group_concat(?type;separator=' ') as ?types) WHERE {" +
                 "<" + uri + "> rdf:type ?type ." +
-        "}");
+                "}");
         QueryExecution queryExecution = executeQuery(query);
 
         try {
             Iterator<QuerySolution> results = queryExecution.execSelect();
             if (results != null) {
-                while(results.hasNext()) {
+                while (results.hasNext()) {
                     QuerySolution result = results.next();
                     types = result.get("types").toString();
                 }
             }
-        }
-        finally {
+        } finally {
             queryExecution.close();
         }
         return types;

--- a/src/main/java/chatbot/lib/api/SPARQL.java
+++ b/src/main/java/chatbot/lib/api/SPARQL.java
@@ -37,7 +37,6 @@ public class SPARQL {
                     "PREFIX dct: <http://purl.org/dc/terms/>\n");
 
     Database explorerDB;
-
     public SPARQL(Database explorerDB) {
         this.explorerDB = explorerDB;
     }
@@ -95,9 +94,9 @@ public class SPARQL {
     // blindly stripping based on brackets
     private String stripWikiepdiaContent(String text) {
         int indexStart = text.indexOf("(");
-        if (indexStart > 0) {
+        if(indexStart > 0) {
             int indexEnd = text.indexOf(")", indexStart);
-            if (indexEnd == -1) {
+            if(indexEnd == -1) {
                 // No closing paren found, return unchanged
                 return text;
             }
@@ -107,7 +106,7 @@ public class SPARQL {
         } else if (indexStart == 0) {
             // When abstract starts with info on Disambiguation
             int disIndex = text.lastIndexOf("(disambiguation).)");
-            if (disIndex == -1) {
+            if(disIndex == -1) {
                 // Pattern not found, return unchanged
                 return text;
             }
@@ -119,7 +118,7 @@ public class SPARQL {
     }
 
     private String processWikipediaAbstract(String abs) {
-        while (abs.indexOf("(") != -1) {
+        while(abs.indexOf("(") != -1) {
             String before = abs;
             abs = stripWikiepdiaContent(abs);
             // Break if no change was made to prevent infinite loop on malformed input
@@ -158,15 +157,15 @@ public class SPARQL {
                     .inclusiveEnd(true)
                     .build().getResponse().getValues();
 
-            for (ExplorerProperties property : explorerProperties) {
-                // Check if the property matches one of the list of classes(types) found for the
-                // entity
-                if (types.contains(property.getClassName())) {
+            for(ExplorerProperties property : explorerProperties)
+             {
+                // Check if the property matches one of the list of classes(types) found for the  entity
+                if(types.contains(property.getClassName())) {
                     propertyMap.put(Float.parseFloat(property.getScore()), property.getProperty());
                 }
             }
 
-            if (propertyMap.size() > 0) {
+            if(propertyMap.size() > 0) {
                 int count = 0;
                 Iterator<Float> iterator = propertyMap.descendingKeySet().iterator();
                 String property_uris = "";
@@ -186,7 +185,7 @@ public class SPARQL {
                 QueryExecution queryExecution = executeQuery(query);
                 try {
                     Iterator<QuerySolution> results = queryExecution.execSelect();
-                    while (results.hasNext()) {
+                    while(results.hasNext()) {
                         QuerySolution result = results.next();
                         ResponseData.Field field = new ResponseData.Field();
                         field.setName(Utility.capitalizeAll(result.get("property_label").asLiteral().getString()));
@@ -237,7 +236,7 @@ public class SPARQL {
                 result.get("primaryTopic").toString()));
 
         node = result.get("thumbnail");
-        if (node != null) {
+        if(node != null) {
             responseData.setImage(node.toString());
         }
 
@@ -250,7 +249,7 @@ public class SPARQL {
         // }
 
         node = result.get("description");
-        if (node != null) {
+        if(node != null) {
             text += node.asLiteral().getString() + "\n\n";
         }
 
@@ -275,29 +274,28 @@ public class SPARQL {
         QueryExecution queryExecution = executeQuery(query);
         try {
             Iterator<QuerySolution> results = queryExecution.execSelect();
-            while (results.hasNext()) {
+            while(results.hasNext()) {
                 QuerySolution solution = results.next();
-                if (solution.get("types") != null && solution.get("properties") != null) {
+                if(solution.get("types") != null && solution.get("properties") != null) {
                     List<String> types = Arrays.asList(solution.get("types").asLiteral().getString().split(" "));
                     String[] properties = solution.get("properties").asLiteral().getString().split(" ");
                     responseData.setFields(getRelevantProperties(uri, types, properties));
                 }
             }
-        } finally {
+        }
+        finally {
             queryExecution.close();
         }
 
         responseData.addButton(new ResponseData.Button("View in DBpedia", ResponseType.BUTTON_LINK, uri));
-        responseData.addButton(new ResponseData.Button("Learn More", ResponseType.BUTTON_PARAM,
-                TemplateType.LEARN_MORE + Utility.STRING_SEPARATOR + uri + Utility.STRING_SEPARATOR + label));
+        responseData.addButton(new ResponseData.Button("Learn More", ResponseType.BUTTON_PARAM,TemplateType.LEARN_MORE + Utility.STRING_SEPARATOR + uri + Utility.STRING_SEPARATOR + label));
         return responseData;
     }
 
     private String getEntityWhereCondition(String uri) {
-        // URI could either be the actual URI or a variable reference
-        // In case of actual URI it needs to be enclosed with <uri> which is not
-        // required for variable reference
-        if (!uri.startsWith("?")) {
+        // URI could either be the actual URI or a variable reference 
+        //In case of actual URI it needs to be enclosed with <uri> which is not  required for variable reference
+        if(!uri.startsWith("?")) {
             uri = "<" + uri + ">";
         }
         return uri + " rdfs:label ?label .\n" +
@@ -311,17 +309,18 @@ public class SPARQL {
     public ResponseData getEntityInformation(String uri) {
         String query = buildQuery("SELECT " + ENTITY_SELECT_PARAMETERS + " WHERE {" +
                 getEntityWhereCondition(uri) +
-                "}");
+        "}");
         QueryExecution queryExecution = executeQuery(query);
         ResponseData responseData = null;
 
         try {
             Iterator<QuerySolution> results = queryExecution.execSelect();
-            while (results.hasNext()) {
+            while(results.hasNext()) {
                 QuerySolution result = results.next();
                 responseData = processEntityInformation(uri, result);
             }
-        } finally {
+        } 
+        finally {
             queryExecution.close();
         }
         return responseData;
@@ -330,23 +329,23 @@ public class SPARQL {
     /**
      * Returns 0 if it is not a disambiguation page. Returns count otherwise
      * We can only show 10 at a time so its limited by that
-     * 
      * @return 0 or count
      */
     public int isDisambiguationPage(String uri) {
-        String query = buildQuery("SELECT (count(*) as ?count) WHERE {" +
-                "<" + uri + "> <http://dbpedia.org/ontology/wikiPageDisambiguates> ?o." +
-                "}");
+    String query = buildQuery("SELECT (count(*) as ?count) WHERE {" +
+            "<" + uri + "> <http://dbpedia.org/ontology/wikiPageDisambiguates> ?o." +
+            "}");
         QueryExecution queryExecution = executeQuery(query);
         int count = 0;
 
         try {
             Iterator<QuerySolution> results = queryExecution.execSelect();
-            while (results.hasNext()) {
+            while(results.hasNext()) {
                 QuerySolution result = results.next();
                 count = result.get("count").asLiteral().getInt();
             }
-        } finally {
+        } 
+        finally {
             queryExecution.close();
         }
         return count;
@@ -360,12 +359,13 @@ public class SPARQL {
             Iterator<QuerySolution> results = queryExecution.execSelect();
             if (results != null) {
                 responseDatas = new ArrayList<>();
-                while (results.hasNext()) {
+                while(results.hasNext()) {
                     QuerySolution result = results.next();
                     responseDatas.add(processEntityInformation(result.get("uri").toString(), result));
                 }
             }
-        } finally {
+        } 
+        finally {
             queryExecution.close();
         }
         return responseDatas;
@@ -417,12 +417,13 @@ public class SPARQL {
         try {
             Iterator<QuerySolution> results = queryExecution.execSelect();
             if (results != null) {
-                while (results.hasNext()) {
+                while(results.hasNext()) {
                     QuerySolution result = results.next();
                     types = result.get("types").toString();
                 }
             }
-        } finally {
+        } 
+        finally {
             queryExecution.close();
         }
         return types;


### PR DESCRIPTION
## Summary
Fixes CouchDB unavailability crashes and improves error handling when database is down.

## Key Changes
- **Application.java**: Better error logging, safe SPARQL initialization, add `isExplorerDBAvailable()`
- **SPARQL.java**: Complete `disabled()` method with all overrides, fix bounds exception in text processing

## Impact
- ✅ No crashes when CouchDB unavailable
- ✅ User-friendly error messages
- ✅ Prevents NPE in pagination
- ✅ Safe text processing

Resolves #44 
closes #44 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a clear "Explorer database unavailable" indicator and exposes a public check for explorer availability.

* **Bug Fixes**
  * Prevents crashes and preserves responsiveness when one or more backend databases are partially unavailable by using safe fallbacks.
  * Null-safe handling avoids lookup/search failures and returns safe defaults instead of errors.

* **Chores**
  * More granular error logging and per-database initialization so one failure doesn't stop others.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->